### PR TITLE
Fixes the check to avoid to put MSPDEV comments in empty blocks

### DIFF
--- a/Model/BlockProcessor.php
+++ b/Model/BlockProcessor.php
@@ -56,7 +56,7 @@ class BlockProcessor
      */
     public function wrapBlock($html, $blockId, $name)
     {
-        if ($html) {
+        if (trim($html)) {
             $html = '<!-- START_MSPDEV[' . $blockId . ']: ' . $name . ' -->' . $html
             . '<!-- END_MSPDEV[' . $blockId . ']: ' . $name . ' -->';
  


### PR DESCRIPTION
Fixes the check to avoid to put MSPDEV comments in empty blocks.
There could be some empty blocks with characters like new lines or spaces so we trim their html when deciding to put MSPDEV comments or not.