### PR TITLE
add callstack to page info for query logging

### DIFF
--- a/Model/PageInfo.php
+++ b/Model/PageInfo.php
@@ -385,11 +385,18 @@ class PageInfo
                     continue;
                 }
 
+                $trace = '';
+                if ($query instanceof \MSP\DevTools\Profiler\Db\Db_Profiler_Query) {
+                    $trace = $query->getStacktrace();
+                }
+
                 $allQueries[] = [
                     'sql' => $query->getQuery(),
                     'time' => $query->getElapsedSecs(),
                     'grade' => 'medium',
+                    'trace' => $trace
                 ];
+
             }
         }
 

--- a/Profiler/Db/Db_Profiler.php
+++ b/Profiler/Db/Db_Profiler.php
@@ -1,0 +1,56 @@
+<?php
+namespace MSP\DevTools\Profiler\Db;
+/**
+ * @author      Benjamin Rosenberger <rosenberger@e-conomix.at>
+ * @package
+ * @copyright   Copyright (c) 2017 E-CONOMIX GmbH (http://www.e-conomix.at)
+ */
+
+class Db_Profiler extends \Zend_Db_Profiler
+{
+    public function queryEnd($queryId)
+    {
+        $result = parent::queryEnd($queryId);
+        $this->getQueryProfile($queryId)->setStacktrace((new \Exception)->getTraceAsString());
+        return $result;
+    }
+
+    public function queryStart($queryText, $queryType = null)
+    {
+        if (!$this->_enabled) {
+            return null;
+        }
+
+        // make sure we have a query type
+        if (null === $queryType) {
+            switch (strtolower(substr(ltrim($queryText), 0, 6))) {
+                case 'insert':
+                    $queryType = self::INSERT;
+                    break;
+                case 'update':
+                    $queryType = self::UPDATE;
+                    break;
+                case 'delete':
+                    $queryType = self::DELETE;
+                    break;
+                case 'select':
+                    $queryType = self::SELECT;
+                    break;
+                default:
+                    $queryType = self::QUERY;
+                    break;
+            }
+        }
+
+        /**
+         * @see Zend_Db_Profiler_Query
+         */
+        #require_once 'Zend/Db/Profiler/Query.php';
+        $this->_queryProfiles[] = new \MSP\DevTools\Profiler\Db\Db_Profiler_Query($queryText, $queryType);
+
+        end($this->_queryProfiles);
+
+        return key($this->_queryProfiles);
+    }
+
+}

--- a/Profiler/Db/Db_Profiler_Query.php
+++ b/Profiler/Db/Db_Profiler_Query.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * @author      Benjamin Rosenberger <rosenberger@e-conomix.at>
+ * @package
+ * @copyright   Copyright (c) 2017 E-CONOMIX GmbH (http://www.e-conomix.at)
+ */
+
+namespace MSP\DevTools\Profiler\Db;
+
+
+class Db_Profiler_Query extends \Zend_Db_Profiler_Query
+{
+    protected $stacktrace;
+
+    public function setStacktrace($stacktrace) {
+        $this->stacktrace = $stacktrace;
+    }
+
+    public function getStacktrace() {
+        return $this->stacktrace;
+    }
+}


### PR DESCRIPTION
following configuration is needed in order to activate this features within the app/etc/env.php:

'db' => [
        'connection' => [
            'default' => [
                ...
                'profiler' => [
                    'enabled' => '1',
                    'class' => '\MSP\DevTools\Profiler\Db\Db_Profiler'
                ]
            ]
        ]
    ],

solves #38 
not a pretty view within the chrome-toolbar, but at least the information where query is executed is present