### PR TITLE
don't inject if contentType is application/json

### DIFF
--- a/Plugin/PhpEnvironment/ResponsePlugin.php
+++ b/Plugin/PhpEnvironment/ResponsePlugin.php
@@ -98,8 +98,11 @@ class ResponsePlugin
         \Closure $proceed
     ) {
         $res = $proceed();
-
         if ($this->config->canInjectCode()) {
+            $contentType = $subject->getHeader('content-type');
+            if ($contentType && $contentType->match('application/json')) {
+                return $res;
+            }
             if ($subject instanceof HttpResponse) {
                 $this->elementRegistry->calcTimers();
                 $this->eventRegistry->calcTimers();


### PR DESCRIPTION
When a controller that returns a json response the end result is an invalid json becouse due to the injected script.
