### PR TITLE
Add PHP 8.1 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "msp/devtools",
   "description": "",
   "require": {
-    "php": "^7.0|^8.1",
+    "php": "^7.4|^8.1",
     "msp/common": "*",
 
     "magento/magento-composer-installer": "*"

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "msp/devtools",
   "description": "",
   "require": {
-    "php": "^7.0|^7.1",
+    "php": "^7.0|^8.1",
     "msp/common": "*",
 
     "magento/magento-composer-installer": "*"


### PR DESCRIPTION
I found the DevTools to be working so far without issues under PHP 8.1 (with Magento 2.4.4). This PR also changes the PHP 7 requirement notation: `^7.0` already matches PHP 7.1 and above.