### PR TITLE
Resolve Deprecated Functionality: preg_split(): Passing null to parameter #2 ($subject)….

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -176,7 +176,7 @@ class Config
      */
     public function getAllowedRanges()
     {
-        $ranges = $this->scopeConfig->getValue(self::XML_PATH_GENERAL_AUTHORIZED_IPS);
+        $ranges = $this->scopeConfig->getValue(self::XML_PATH_GENERAL_AUTHORIZED_IPS) ?? "";
         return preg_split('/\s*[,;]+\s*/', $ranges);
     }
 


### PR DESCRIPTION
… while using PHP 8.0+

In new versions of PHP (8.*) the Second Parameter subject can't be null so if the $ranges is null then this will throw the exception: `Exception #0 (Exception): Deprecated Functionality: preg_split(): Passing null to parameter #2 ($subject).....`. That crash the code flow. So this commit solved the problem.