### PR TITLE
First line of js block is ignored fix

### DIFF
--- a/Model/BlockProcessor.php
+++ b/Model/BlockProcessor.php
@@ -57,8 +57,8 @@ class BlockProcessor
     public function wrapBlock($html, $blockId, $name)
     {
         if (trim($html)) {
-            $html = '<!-- START_MSPDEV[' . $blockId . ']: ' . $name . ' -->' . $html
-            . '<!-- END_MSPDEV[' . $blockId . ']: ' . $name . ' -->';
+            $html = '<!-- START_MSPDEV[' . $blockId . ']: ' . $name . ' -->' . PHP_EOL . $html
+            . '<!-- END_MSPDEV[' . $blockId . ']: ' . $name . ' -->' . PHP_EOL;
 
         }
         return $html;

--- a/Plugin/View/LayoutPlugin.php
+++ b/Plugin/View/LayoutPlugin.php
@@ -90,8 +90,8 @@ class LayoutPlugin
             return $html;
         }
 
-        $html = '<!-- START_MSPDEV[' . $blockId . ']: ' . $name . ' -->' . $html
-            . '<!-- /END_MSPDEV[' . $blockId . ']: ' . $name . ' -->';
+        $html = '<!-- START_MSPDEV[' . $blockId . ']: ' . $name . ' -->' . PHP_EOL . $html
+            . '<!-- /END_MSPDEV[' . $blockId . ']: ' . $name . ' -->' . PHP_EOL;
 
         return $html;
     }


### PR DESCRIPTION
Hey,

when you load a block that contains just a javascript part .. like in my case recaptcha validation .. the first line will be ignored if there is a html comment.

```
<!-- START_MSPDEV[4c5bc1e9b965d3ccc4854fabd9e78c7f]: recaptcha_validation_recaptcha -->    this.hasCaptchaToken = $form['g\u002Drecaptcha\u002Dresponse'] ..
```

simple version (it's not executed)
```
<!-- comment --> const test = 1;
```

My solution is just to put a PHP_EOL after the comment.

Regards
Marcus