### PR TITLE
Prevent error on json response pages.

### DIFF
--- a/Model/BlockProcessor.php
+++ b/Model/BlockProcessor.php
@@ -56,6 +56,10 @@ class BlockProcessor
      */
     public function wrapBlock($html, $blockId, $name)
     {
+        if (!$html) {
+            return "";
+        }
+        
         if (trim($html)) {
             $html = '<!-- START_MSPDEV[' . $blockId . ']: ' . $name . ' -->' . $html
             . '<!-- END_MSPDEV[' . $blockId . ']: ' . $name . ' -->';


### PR DESCRIPTION
Prevent error on json response pages. If the HTML is empty (in our case because it's a json response ajax page), return an empty string so the trim() does not fail